### PR TITLE
Upgrade rc to deploy

### DIFF
--- a/staging/volumes/nfs/README.md
+++ b/staging/volumes/nfs/README.md
@@ -158,6 +158,11 @@ nfs-busybox-w3s4t
 ```
 
 
+On Minikube, you may also:
+
+```console
+kubectl expose service nfs-web --name web --port 80 --external-ip=$(minikube ip)
+```
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->

--- a/staging/volumes/nfs/chart/templates/nfs-busybox-deploy.yaml
+++ b/staging/volumes/nfs/chart/templates/nfs-busybox-deploy.yaml
@@ -1,14 +1,15 @@
 # This mounts the nfs volume claim into /mnt and continuously
 # overwrites /mnt/index.html with the time and hostname of the pod.
 
-apiVersion: v1
-kind: ReplicationController
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
   name: nfs-busybox
 spec:
   replicas: 2
   selector:
-    name: nfs-busybox
+    matchLabels:
+      name: nfs-busybox
   template:
     metadata:
       labels:

--- a/staging/volumes/nfs/chart/templates/nfs-server-deploy.yaml
+++ b/staging/volumes/nfs/chart/templates/nfs-server-deploy.yaml
@@ -1,11 +1,12 @@
-apiVersion: v1
-kind: ReplicationController
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
   name: nfs-server
 spec:
   replicas: 1
   selector:
-    role: nfs-server
+    matchLabels:
+      role: nfs-server
   template:
     metadata:
       labels:

--- a/staging/volumes/nfs/chart/templates/nfs-web-deploy.yaml
+++ b/staging/volumes/nfs/chart/templates/nfs-web-deploy.yaml
@@ -1,14 +1,15 @@
 # This pod mounts the nfs volume claim into /usr/share/nginx/html and
 # serves a simple web page.
 
-apiVersion: v1
-kind: ReplicationController
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
   name: nfs-web
 spec:
   replicas: 2
   selector:
-    role: web-frontend
+    matchLabels:
+      role: web-frontend
   template:
     metadata:
       labels:


### PR DESCRIPTION
This change is based on kubernetes/examples#108

Is there any reason to use replicationcontrollers over deployments in October 2017?